### PR TITLE
27 add import for articles

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+tools/importer

--- a/tools/importer/import-category.js
+++ b/tools/importer/import-category.js
@@ -1,0 +1,90 @@
+const formatUrl = (originalUrl) => {
+  // Create a URL object based on the original URL
+  const url = new URL(originalUrl);
+
+  // Set the new domain (including protocol)
+  url.hostname = 'main--best-cigars-guide--famous-smoke.hlx.page';
+  url.protocol = 'https:';
+  url.port = '';
+
+  return url;
+};
+
+const createMetadataBlock = (main, document) => {
+  const meta = {};
+
+  // find the <title> element
+  const title = document.querySelector('title');
+  if (title) {
+    meta.Title = title.innerHTML.replace(/[\n\t]/gm, '');
+  }
+
+  // find the <meta property="og:description"> element
+  const desc = document.querySelector('[property="og:description"]');
+  if (desc) {
+    meta.Description = desc.content;
+  }
+
+  // set the <meta property="og:image"> element
+  meta.image = 'https://main--best-cigars-guide--famous-smoke.hlx.page/best-cigars-guide/icons/best-cigars-guide.png';
+
+  // helper to create the metadata block
+  const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+
+  // append the block to the main element
+  main.append(block);
+
+  // returning the meta object might be usefull to other rules
+  return meta;
+};
+
+const createArticleListBlock = (main, document) => {
+  const categories = [['Article-list']];
+  const categoriesList = document.querySelector('.categories-list');
+  const divElements = categoriesList.querySelectorAll('div');
+
+  divElements.forEach((element) => {
+    const title = element.querySelector('h3').textContent.trim();
+    const description = element.querySelector('p').textContent.trim();
+    const image = element.querySelector('img');
+
+    const linkElement = element.querySelector('a.button');
+    linkElement.class = 'button';
+    const link = linkElement ? linkElement.href : '';
+
+    const card = [
+      [image],
+      [title],
+      [description],
+      [formatUrl(link)],
+    ];
+
+    categories.push(card);
+  });
+
+  const articleList = WebImporter.DOMUtils.createTable(categories, document);
+
+  main.append(articleList);
+
+  // remove .categories-list from main because we just added it manually
+  WebImporter.DOMUtils.remove(main, ['.categories-list']);
+
+  return articleList;
+};
+
+const removeSectionsNotForImport = (main, document) => {
+  // remove any section from main not needed for import
+  WebImporter.DOMUtils.remove(main, ['.category-dropdown', '.breadcrumb']);
+};
+
+export default {
+  transformDOM: ({ document }) => {
+    const main = document.querySelector('main');
+
+    createMetadataBlock(main, document);
+    createArticleListBlock(main, document);
+    removeSectionsNotForImport(main, document);
+
+    return main;
+  },
+};

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -28,6 +28,10 @@ const createMetadataBlock = (post, document) => {
     el.src = img.src;
     meta.Image = el;
   }
+
+  // Get the published date
+  const published = new Date(document.querySelector('[property="article:published_time"]').content);
+  meta.publishedDate = `${published.getDate()} ${published.toLocaleDateString('default', { month: 'long'})} ${published.getFullYear()}`;
   // end modified
 
   // helper to create the metadata block
@@ -89,4 +93,8 @@ export default {
     createMetadataBlock(post, document);
     return post;
   },
+
+  generateDocumentPath: ({ document, url, html, params }) => {
+    return document.querySelector("link[rel='canonical']").getAttribute("href");
+  }
 };

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -1,0 +1,92 @@
+/*
+* AEM Article Import Script for Best Cigars Guide Articles
+* Run aem import to use this file
+*/
+
+// Import meta data
+// Taken from https://github.com/adobe/helix-importer-ui/blob/main/importer-guidelines.md
+const createMetadataBlock = (post, document) => {
+  const meta = {};
+
+  // find the <title> element
+  const title = document.querySelector('title');
+  if (title) {
+    meta.Title = title.innerHTML.replace(/[\n\t]/gm, '');
+  }
+
+  // find the <meta property="og:description"> element
+  const desc = document.querySelector('[property="og:description"]');
+  if (desc) {
+    meta.Description = desc.content;
+  }
+
+  // Modified for best-cigars-guide: get the WP hero image
+  const img = document.querySelector('.lrg-image img');
+  if (img) {
+    // create an <img> element
+    const el = document.createElement('img');
+    el.src = img.src;
+    meta.Image = el;
+  }
+  // end modified
+
+  // helper to create the metadata block
+  const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+
+  // append the block to the main element
+  post.append(block);
+
+  // returning the meta object might be usefull to other rules
+  return meta;
+};
+
+// Create the individual item blocks for each cigar/accessory on the page
+const createItemBlocks = (post, document) => {
+  const items = document.querySelectorAll('.cigars-listing .cigar');
+  if (!items || items.length === 0) {
+    // no blocks to add
+    return [];
+  }
+
+  for (const item of items) {
+    // Find general item attributes
+    const cell = [
+      ['Item'],
+      ['Name', item.querySelector('h3') ? item.querySelector('h3').textContent : ''],
+      ['Link', item.querySelector('a').href.replace('http://localhost:3001', 'https://www.famous-smoke.com')],
+      ['Description', item.querySelector('.cigar-info p').textContent],
+      ['Image', item.querySelector('img')],
+      ['Rating', item.querySelectorAll('.star-rating img[src$="star.png"]').length],
+    ];
+
+    // Add in cigar specific attributes
+    if (item.querySelector('.cigar-stats .stat1 p:last-child')) {
+      cell.push(['Country', item.querySelector('.cigar-stats .stat1 p:last-child').textContent]);
+    }
+    if (item.querySelector('.cigar-stats .stat2 p:last-child')) {
+      cell.push(['Strength', item.querySelector('.cigar-stats .stat2 p:last-child').textContent]);
+    }
+    if (item.querySelector('.cigar-stats .stat3 p:last-child')) {
+      cell.push(['Wrapper', item.querySelector('.cigar-stats .stat3 p:last-child').textContent]);
+    }
+    if (item.querySelector('.cigar-stats .stat4 p:last-child')) {
+      cell.push(['Color', item.querySelector('.cigar-stats .stat4 p:last-child').textContent]);
+    }
+
+    // Add the block and remove the non-block HTML
+    const block = WebImporter.DOMUtils.createTable(cell, document);
+    post.append(block);
+    if (document.querySelector('.cigars-listing')) {
+      document.querySelector('.cigars-listing').remove();
+    }
+  }
+};
+
+export default {
+  transformDOM: ({ document }) => {
+    const post = document.querySelector('article.post');
+    createItemBlocks(post, document);
+    createMetadataBlock(post, document);
+    return post;
+  },
+};


### PR DESCRIPTION
Add the import script for articles. I added the generated articles into Sharepoint, unpublished. Since these are unpublished, there's not really much you can test URL wise.

Run "aem import" to view and run imports based off this import script. View the created blocks, page content, images, and meta data are added into the generated documents - note there is no styling yet for these article pages. I added this import file to the eslintignore list since this is a one-time use import script from our current best cigars guide site. 

Fix #27 

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
- After: https://27-add-import-for-articles--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
