### PR TITLE
Add ld+json data to pages

### DIFF
--- a/best-cigars-guide/blocks/footer/footer.js
+++ b/best-cigars-guide/blocks/footer/footer.js
@@ -1,6 +1,39 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 import { isInternal } from '../../scripts/scripts.js';
+import { addLdJsonScript } from '../../scripts/linking-data.js';
+
+function buildLdJson(container) {
+  // Base page LD+JSON
+  const ldJson = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': window.location.href,
+    url: window.location.href,
+    description: getMetadata('description'),
+    author: {
+      '@type': 'Organization',
+      '@id': 'https://www.famous-smoke.com',
+    },
+    inLanguage: 'en-US',
+  };
+
+  // Change type for category pages
+  if (document.querySelector('.article-list-container')) {
+    ldJson['@type'] = 'CollectionPage';
+  }
+
+  // Add image from metadata
+  const primaryImage = getMetadata('og:image');
+  if (primaryImage) {
+    ldJson.primaryImageOfPage = {
+      '@type': 'ImageObject',
+      contentUrl: getMetadata('og:image'),
+    };
+  }
+
+  addLdJsonScript(container, ldJson);
+}
 
 function getFamousLogo() {
   // Create the image element
@@ -31,6 +64,9 @@ export default async function decorate(block) {
   const footerMeta = getMetadata('footer');
   const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/best-cigars-guide/footer';
   const fragment = await loadFragment(footerPath);
+
+  // add json-ld data for the page
+  buildLdJson(document.body);
 
   // decorate footer DOM
   block.textContent = '';

--- a/best-cigars-guide/scripts/linking-data.js
+++ b/best-cigars-guide/scripts/linking-data.js
@@ -1,0 +1,12 @@
+/**
+ * Writes a script element with the LD JSON struct to the page
+ * @param {HTMLElement} parent
+ * @param {Object} json
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function addLdJsonScript(parent, json) {
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.innerHTML = JSON.stringify(json);
+  parent.append(script);
+}

--- a/head.html
+++ b/head.html
@@ -2,3 +2,24 @@
 <script src="/best-cigars-guide/scripts/aem.js" type="module"></script>
 <script src="/best-cigars-guide/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/best-cigars-guide/styles/styles.css"/>
+<script type="application/ld+json">
+    {
+        "@context":"https://schema.org",
+        "@type": "WebSite",
+        "@id": "https://www.famous-smoke.com/best-cigars-guide/",
+        "url": "https://www.famous-smoke.com/best-cigars-guide/",
+        "name": "Famous Smoke Shop - Best Cigars Selection Guide",
+        "description": "Find the Best Recommended Cigars",
+        "potentialAction": [
+            {
+                "@type": "SearchAction",
+                "target": {
+                    "@type": "EntryPoint",
+                    "urlTemplate": "https://www.famous-smoke.com/best-cigars-guide/?q={search_term_string}"
+                },
+                "query-input": "required name=search_term_string"
+            }
+        ],
+        "inLanguage": "en-US"
+    }
+</script>


### PR DESCRIPTION
Adds LD+JSON data to all pages for the website and page content.

Fix #30 

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
- After: https://30-article-links-jsonld--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
