### PR TITLE
Add half star ratings to the articles import

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -61,8 +61,14 @@ const createItemBlocks = (post, document) => {
   }
 
   for (const item of items) {
+    // Calculate rating
+    let rating = item.querySelectorAll('.star-rating img[src$="star.png"]').length;
+    if (item.querySelector('.star-rating img[src$="star-half.png"]')) {
+      rating = rating + 0.5;
+    }
+
     // Find general item attributes
-    const cell = [['Item'], ['Name', item.querySelector('h3') ? item.querySelector('h3').textContent : ''], ['Link', item.querySelector('a').href.replace('http://localhost:3001', 'https://www.famous-smoke.com')], ['Description', item.querySelector('.cigar-info p').textContent], ['Image', item.querySelector('img')], ['Rating', item.querySelectorAll('.star-rating img[src$="star.png"]').length]];
+    const cell = [['Item'], ['Name', item.querySelector('h3') ? item.querySelector('h3').textContent : ''], ['Link', item.querySelector('a').href.replace('http://localhost:3001', 'https://www.famous-smoke.com')], ['Description', item.querySelector('.cigar-info p').textContent], ['Image', item.querySelector('img')], ['Rating', rating]];
 
     // Add in cigar specific attributes
     if (item.querySelector('.cigar-stats .stat1 p:last-child')) {


### PR DESCRIPTION
Fixes half stars for item ratings not being imported in the articles import. All articles have been re-imported into Sharepoint.

Sample page with an item with a half star rating: /best-cigars-guide/best-cigars-by-country/top-10-dominican-cigars - La Aurora Preferidos Gold Dominican Corojo should have 4.5 stars:

<img width="717" alt="image" src="https://github.com/famous-smoke/best-cigars-guide/assets/11136895/143d457f-a4d2-4cb2-b520-558dc14dc5b9">

Fix #43

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
- After: https://43-half-star-fix--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
