### PR TITLE
Fix aspect ratio for article list images

### DIFF
--- a/best-cigars-guide/blocks/article-list/article-list.css
+++ b/best-cigars-guide/blocks/article-list/article-list.css
@@ -44,7 +44,6 @@
   height: auto;
   transition: transform 0.3s ease;
   line-height: 0;
-  aspect-ratio: 4 / 3;
   object-fit: cover;
 }
 


### PR DESCRIPTION
Fix #48, removes aspect ratio from CSS for article list images. 

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/
- After: https://48-img-zoom--best-cigars-guide--famous-smoke.hlx.live/
