### PR TITLE
use index title for category dropdown

### DIFF
--- a/best-cigars-guide/blocks/nav/nav.js
+++ b/best-cigars-guide/blocks/nav/nav.js
@@ -79,11 +79,7 @@ async function createCategoriesDropdown() {
   categoriesList.forEach((category) => {
     const option = document.createElement('option');
     option.value = category.path;
-    option.textContent = category.path
-      .split('/')
-      .pop()
-      .replace(/-/g, ' ')
-      .replace(/\b\w/g, (char) => char.toUpperCase());
+    option.textContent = category.title.split('|')[0].trim();
     const categoryPath = category.path.split('/').slice(0, 3).join('/');
     if (categoryPath === currentCategoryPath) {
       option.selected = true;

--- a/best-cigars-guide/scripts/scripts.js
+++ b/best-cigars-guide/scripts/scripts.js
@@ -19,7 +19,7 @@ export async function fetchCategoryList() {
       const resp = await fetch(CATEGORY_INDEX_PATH);
       if (resp.ok) {
         const jsonData = await resp.json();
-        categoryIndexData = jsonData.data.map((item) => ({ path: item.path }));
+        categoryIndexData = jsonData.data.map((item) => ({ path: item.path, title: item.title }));
       } else {
         // eslint-disable-next-line no-console
         console.error('Failed to fetch category list:', resp.status);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #50 

Category drop down should be using the title from category-index.json.
Specifically, the dropdown text value for /best-cigars-by-shape-type-size should be 'Best Cigars By Shape, Type & Size'
H1 and meta title should match on category pages.

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide/best-cigars-by-country
- After: https://50-category-dropdown--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide/best-cigars-by-country
