### PR TITLE
Add hreflang link attribute to head

### DIFF
--- a/best-cigars-guide/scripts/scripts.js
+++ b/best-cigars-guide/scripts/scripts.js
@@ -214,6 +214,9 @@ export function isInternal(path) {
   }
 }
 
+/**
+ * Add hreflang link attribute to head
+ */
 function addHreflang() {
   const el = document.createElement('link');
   el.rel = 'alternate';

--- a/best-cigars-guide/scripts/scripts.js
+++ b/best-cigars-guide/scripts/scripts.js
@@ -214,12 +214,22 @@ export function isInternal(path) {
   }
 }
 
+function addHreflang() {
+  const el = document.createElement('link');
+  el.rel = 'alternate';
+  el.hreflang = 'en';
+  el.href = window.location.href;
+
+  document.head.appendChild(el);
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
   document.documentElement.lang = 'en';
+  addHreflang();
   decorateTemplateAndTheme();
   const main = doc.querySelector('main');
   if (main) {


### PR DESCRIPTION
hreflang link attribute should be added to every page, only for English.

Fix #67 

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/
- After: https://67-hreflang--best-cigars-guide--famous-smoke.hlx.live/
