### PR TITLE
Change GTM ID to match Famous

### DIFF
--- a/best-cigars-guide/scripts/delayed.js
+++ b/best-cigars-guide/scripts/delayed.js
@@ -19,7 +19,7 @@ function onGALoad() {
     dataLayer.push(arguments);
   }
   gtag('js', new Date());
-  gtag('config', 'GT-M6QM788');
+  gtag('config', 'G-S1GMVHJEKZ');
   gtag('set', 'linker', { domains: ['www.famous-smoke.com'] });
 }
 
@@ -27,7 +27,7 @@ function loadGoogleAnalytics() {
   // Load the Google Analytics library
   const tag = document.createElement('script');
   tag.async = true;
-  tag.src = 'https://www.googletagmanager.com/gtag/js?id=GT-M6QM788';
+  tag.src = 'https://www.googletagmanager.com/gtag/js?id=G-S1GMVHJEKZ';
   document.head.appendChild(tag);
   // Configuration script
   tag.onload = onGALoad;


### PR DESCRIPTION
Changes GTM ID to match Famous. 

Fix #71 

Test URLs:
- Before: https://main--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
- After: https://71-change-gtm-id--best-cigars-guide--famous-smoke.hlx.live/best-cigars-guide
